### PR TITLE
Improve cross-platform support by adopting numpy types

### DIFF
--- a/pyapprox/adaptive_polynomial_chaos.py
+++ b/pyapprox/adaptive_polynomial_chaos.py
@@ -27,8 +27,8 @@ def get_active_poly_array_indices(adaptive_pce):
     return indices
 
 def variance_pce_refinement_indicator(
-        subspace_index,num_new_subspace_samples,adaptive_pce,
-        normalize=True,mean_only=False):
+        subspace_index, num_new_subspace_samples, adaptive_pce,
+        normalize=True, mean_only=False):
     """
     Set pce coefficients of new subspace poly indices to zero to compute
     previous mean then set them to be non-zero
@@ -37,24 +37,24 @@ def variance_pce_refinement_indicator(
     ii = adaptive_pce.active_subspace_indices_dict[key]
     I = get_subspace_active_poly_array_indices(adaptive_pce,ii)
     error = np.sum(adaptive_pce.pce.coefficients[I]**2,axis=0)
-    indicator=error.copy()
-    #print(subspace_index,error)
+    indicator = error.copy()
                 
     # relative error will not work if value at first grid point is close to zero
     if normalize:
-        assert np.all(np.absolute(adaptive_pce.values[0,:])>1e-6)
-        indicator/=np.absolute(adaptive_pce.values[0,:])**2
+        first_vals = np.absolute(adaptive_pce.values[0,:])
+        assert np.all(first_vals > 1e-6)
+        indicator /= np.absolute(first_vals)**2
 
     qoi_chosen = np.argmax(indicator)
 
-    indicator=indicator.max()
+    indicator = indicator.max()
 
     cost_per_sample = adaptive_pce.eval_cost_function(
-        subspace_index[:,np.newaxis])
+                        subspace_index[:,np.newaxis])
     cost = cost_per_sample*num_new_subspace_samples
 
     # compute marginal benefit
-    indicator/=cost
+    indicator /= cost
     #print(subspace_index,indicator,'indicator')
     return -indicator, error[qoi_chosen]
     

--- a/pyapprox/adaptive_polynomial_chaos.py
+++ b/pyapprox/adaptive_polynomial_chaos.py
@@ -43,7 +43,7 @@ def variance_pce_refinement_indicator(
     if normalize:
         first_vals = np.absolute(adaptive_pce.values[0,:])
         assert np.all(first_vals > 1e-6)
-        indicator /= np.absolute(first_vals)**2
+        indicator /= first_vals**2
 
     qoi_chosen = np.argmax(indicator)
 

--- a/pyapprox/barycentric_interpolation.py
+++ b/pyapprox/barycentric_interpolation.py
@@ -184,25 +184,28 @@ def multivariate_hierarchical_barycentric_lagrange_interpolation(
                 num_act_dims, abscissa_1d, barycentric_weights_1d,
                 active_abscissa_indices_1d)
 
-    if module_exists("pyapprox.cython.barycentric_interpolation"):
+    try:
         from pyapprox.cython.barycentric_interpolation import \
             multivariate_hierarchical_barycentric_lagrange_interpolation_pyx
+
         result = \
             multivariate_hierarchical_barycentric_lagrange_interpolation_pyx(
-                x, fn_vals, active_dims, active_abscissa_indices_1d.astype(np.int_),
-                num_abscissa_1d.astype(np.int_), num_active_abscissa_1d.astype(np.int_),
-                shifts.astype(np.int_), abscissa_and_weights)
+                x, fn_vals, active_dims, active_abscissa_indices_1d,
+                num_abscissa_1d, num_active_abscissa_1d,
+                shifts, abscissa_and_weights)
+
         if np.any(np.isnan(result)):
             raise ValueError('Error values not finite')
+
         return result
-    else:
+    except (ImportError, ModuleNotFoundError) as e:
         msg = 'multivariate_hierarchical_barycentric_lagrange_interpolation extension failed'
-        print(msg)
+        trace_error_with_msg(msg, e)
 
     return __multivariate_hierarchical_barycentric_lagrange_interpolation(
-        x, abscissa_1d, fn_vals, active_dims, active_abscissa_indices_1d,
-        num_abscissa_1d, num_active_abscissa_1d, shifts,
-        abscissa_and_weights)
+                x, abscissa_1d, fn_vals, active_dims, active_abscissa_indices_1d,
+                num_abscissa_1d, num_active_abscissa_1d, shifts,
+                abscissa_and_weights)
 
 
 @njit(cache=True)

--- a/pyapprox/cython/barycentric_interpolation.pyx
+++ b/pyapprox/cython/barycentric_interpolation.pyx
@@ -5,7 +5,7 @@ import numpy as np
 
 
 ctypedef np.double_t double_t
-ctypedef np.int_t int_t
+ctypedef np.int32_t int32_t
 ctypedef np.int64_t int64_t
 
 
@@ -43,9 +43,9 @@ cpdef compute_barycentric_weights_1d_pyx(np.ndarray[double_t] samples, double C_
 @cython.boundscheck(False)  # Deactivate bounds checking
 @cython.wraparound(False)   # Deactivate negative indexing.
 cpdef multivariate_hierarchical_barycentric_lagrange_interpolation_pyx(
-    double[:,:] x, double[:,:] fn_vals, np.ndarray[int64_t] active_dims,
-    int_t[:,:] active_abscissa_indices_1d, int_t[:] num_abscissa_1d,
-    int_t[:] num_active_abscissa_1d, int_t[:] shifts,
+    double[:,:] x, double[:,:] fn_vals, np.ndarray active_dims,
+    int32_t[:,:] active_abscissa_indices_1d, int32_t[:] num_abscissa_1d,
+    int32_t[:] num_active_abscissa_1d, int32_t[:] shifts,
     double[:,:] abscissa_and_weights):
 
     # active_dims is type unstable! Switches from int64 to int32
@@ -61,7 +61,7 @@ cpdef multivariate_hierarchical_barycentric_lagrange_interpolation_pyx(
         Py_ssize_t num_act_dims = active_dims.shape[0]
 
         Py_ssize_t max_num_abscissa_1d = abscissa_and_weights.shape[0]//2
-        int_t[:] multi_index = np.empty((num_act_dims), dtype=np.int_)
+        int32_t[:] multi_index = np.empty((num_act_dims), dtype=np.int32)
 
         Py_ssize_t num_qoi = fn_vals.shape[1]
 
@@ -71,9 +71,9 @@ cpdef multivariate_hierarchical_barycentric_lagrange_interpolation_pyx(
     # Allocate persistent memory. Each point will fill in a varying amount
     # of entries. We use a view of this memory to stop reallocation for each 
     # data point
-    cdef int_t[:] act_dims_pt_persistent = np.empty((num_act_dims),dtype=np.int_)
-    cdef int_t[:] act_dim_indices_pt_persistent = np.empty(
-        (num_act_dims),dtype=np.int_)
+    cdef int32_t[:] act_dims_pt_persistent = np.empty((num_act_dims), dtype=np.int32)
+    cdef int32_t[:] act_dim_indices_pt_persistent = np.empty(
+        (num_act_dims), dtype=np.int32)
 
     cdef:
         double[:,:] c_persistent=np.empty((num_qoi,num_act_dims),dtype=np.float64)
@@ -199,7 +199,7 @@ cpdef multivariate_hierarchical_barycentric_lagrange_interpolation_pyx(
 @cython.wraparound(False)   # Deactivate negative indexing.
 cpdef tensor_product_lagrange_interpolation_pyx(
     double[:, :] x, double[:, :] fn_vals, double[:, :, :] basis_vals_1d,
-    int_t[:, :] active_indices, int_t[:] active_vars):
+    int32_t[:, :] active_indices, int32_t[:] active_vars):
 
     cdef Py_ssize_t ii, jj, dd, kk
     cdef Py_ssize_t nindices = active_indices.shape[1]

--- a/pyapprox/models/wrappers.py
+++ b/pyapprox/models/wrappers.py
@@ -73,14 +73,14 @@ def evaluate_1darray_function_on_2d_array(function, samples, opts=None):
         The value of each requested QoI of the model for each sample
     """
     num_args = get_num_args(function)
-    assert samples.ndim == 2
+    assert samples.ndim == 2, f"2-dimensional array expected, got {samples.ndim}"
     num_samples = samples.shape[1]
     if num_args == 2:
         values_0 = function(samples[:, 0], opts)
     else:
         values_0 = function(samples[:, 0])
     values_0 = np.atleast_1d(values_0)
-    assert values_0.ndim == 1
+    assert values_0.ndim == 1, f"1-dimensional array expected, got {samples.ndim}"
     num_qoi = values_0.shape[0]
     values = np.empty((num_samples, num_qoi), float)
     values[0, :] = values_0

--- a/pyapprox/probability_measure_sampling.py
+++ b/pyapprox/probability_measure_sampling.py
@@ -169,7 +169,7 @@ def generate_independent_random_samples(variable, num_samples,
         Independent samples from the target distribution
     """
     assert type(variable) == IndependentMultivariateRandomVariable, \
-        "`variable` must be of IndependentMultivariateRandomVariable type"
+        f"`variable` must be of IndependentMultivariateRandomVariable type, got {type(variable)}"
     num_vars = variable.num_vars()
 
     samples = np.empty((num_vars, num_samples), dtype=float)

--- a/pyapprox_dev/pyapprox_dev/fenics_models/advection_diffusion.py
+++ b/pyapprox_dev/pyapprox_dev/fenics_models/advection_diffusion.py
@@ -34,6 +34,9 @@ def run_model(function_space, kappa, forcing, init_condition, dt, final_time,
     WARNING: when point sources solution changes significantly when mesh is 
     varied
     """
+    if not has_dla:
+        raise RuntimeError("DLA not available")
+
     mesh = function_space.mesh()
 
     time_independent_boundaries = False


### PR DESCRIPTION
Avoiding use of base python types in cython functions to make cross-platform behaviour more consistent.

Tested and can confirm this resolves issues encountered on Linux (Ubuntu 20.04) and Windows.