### PR TITLE
Simplify package check

### DIFF
--- a/pyapprox/__init__.py
+++ b/pyapprox/__init__.py
@@ -33,3 +33,8 @@ from pyapprox.sensitivity_analysis import *
 from pyapprox.gaussian_network import *
 from pyapprox.gaussian_process import *
 
+import sys
+from pyapprox.sys_utilities import package_available
+
+
+PYA_DEV_AVAILABLE = package_available('pyapprox-dev') and sys.platform != 'win32'

--- a/pyapprox/barycentric_interpolation.py
+++ b/pyapprox/barycentric_interpolation.py
@@ -5,7 +5,7 @@ from numba import njit
 
 from pyapprox.univariate_quadrature import clenshaw_curtis_pts_wts_1D
 from pyapprox.utilities import cartesian_product
-from .sys_utilities import trace_error_with_msg, module_exists
+from .sys_utilities import trace_error_with_msg
 
 
 def compute_barycentric_weights_1d(samples, interval_length=None,
@@ -43,18 +43,14 @@ def compute_barycentric_weights_1d(samples, interval_length=None,
     C_inv = 1/scaling_factor
     num_samples = samples.shape[0]
 
-    if module_exists("pyapprox.cython.barycentric_interpolation"):
+    try:
         from pyapprox.cython.barycentric_interpolation import \
             compute_barycentric_weights_1d_pyx
         
         weights = compute_barycentric_weights_1d_pyx(samples, C_inv)
-    else:
+    except (ImportError, ModuleNotFoundError) as e:
         msg = 'compute_barycentric_weights_1d extension failed'
-        print(msg)
-
-        # X=np.tile(samples[:,np.newaxis],[1,samples.shape[0]])
-        # result=1./np.prod(X-X.T+np.eye(samples.shape[0]),axis=0)
-        # return result
+        trace_error_with_msg(msg, e)
 
         weights = np.empty((num_samples, num_samples), dtype=float)
         weights[0, 0] = 1.
@@ -183,10 +179,11 @@ def multivariate_hierarchical_barycentric_lagrange_interpolation(
             barycentric_lagrange_interpolation_precompute(
                 num_act_dims, abscissa_1d, barycentric_weights_1d,
                 active_abscissa_indices_1d)
-
-    if module_exists("pyapprox.cython.barycentric_interpolation"):
+    
+    try:
         from pyapprox.cython.barycentric_interpolation import \
             multivariate_hierarchical_barycentric_lagrange_interpolation_pyx
+        
         result = \
             multivariate_hierarchical_barycentric_lagrange_interpolation_pyx(
                 x, fn_vals, active_dims, active_abscissa_indices_1d.astype(np.int_),
@@ -194,15 +191,17 @@ def multivariate_hierarchical_barycentric_lagrange_interpolation(
                 shifts.astype(np.int_), abscissa_and_weights)
         if np.any(np.isnan(result)):
             raise ValueError('Error values not finite')
-        return result
-    else:
-        msg = 'multivariate_hierarchical_barycentric_lagrange_interpolation extension failed'
-        print(msg)
 
-    return __multivariate_hierarchical_barycentric_lagrange_interpolation(
-        x, abscissa_1d, fn_vals, active_dims, active_abscissa_indices_1d,
-        num_abscissa_1d, num_active_abscissa_1d, shifts,
-        abscissa_and_weights)
+    except (ImportError, ModuleNotFoundError) as e:
+        msg = 'multivariate_hierarchical_barycentric_lagrange_interpolation extension failed'
+        trace_error_with_msg(msg, e)
+
+        result = __multivariate_hierarchical_barycentric_lagrange_interpolation(
+                    x, abscissa_1d, fn_vals, active_dims, active_abscissa_indices_1d,
+                    num_abscissa_1d, num_active_abscissa_1d, shifts,
+                    abscissa_and_weights)
+
+    return result
 
 
 @njit(cache=True)

--- a/pyapprox/benchmarks/benchmarks.py
+++ b/pyapprox/benchmarks/benchmarks.py
@@ -10,7 +10,6 @@ import pyapprox as pya
 from pyapprox.benchmarks.sensitivity_benchmarks import *
 from pyapprox.benchmarks.surrogate_benchmarks import *
 from pyapprox.models.genz import GenzFunction
-from pyapprox.sys_utilities import package_installed
 from scipy.optimize import OptimizeResult
 
 
@@ -361,7 +360,7 @@ def setup_genz_function(nvars, test_name, coefficients=None):
     return Benchmark(attributes)
 
 
-if package_installed('pyapprox-dev') and sys.platform != 'win32':
+if pya.PYA_DEV_AVAILABLE:
     from pyapprox_dev.fenics_models.advection_diffusion_wrappers import \
         setup_advection_diffusion_benchmark,\
         setup_advection_diffusion_source_inversion_benchmark,\
@@ -377,7 +376,7 @@ def setup_benchmark(name, **kwargs):
                   'rosenbrock': setup_rosenbrock_function,
                   'genz': setup_genz_function,
                   'cantilever_beam': setup_cantilever_beam_benchmark}
-    if package_installed('pyapprox-dev') and sys.platform != 'win32':
+    if pya.PYA_DEV_AVAILABLE:
         # will fail if fenics is not installed and the import of the fenics
         # benchmarks fail
         fenics_benchmarks = {

--- a/pyapprox/benchmarks/test_benchmarks.py
+++ b/pyapprox/benchmarks/test_benchmarks.py
@@ -1,16 +1,10 @@
 #!/usr/bin/env python
-import sys
-from functools import partial
-import unittest, pytest
+import unittest
 
 import numpy as np
-import matplotlib.pyplot as plt
 
-if sys.platform == 'win32':
-    pytestmark = pytest.mark.skip("Skipping test on Windows")
-else:
-    from pyapprox.benchmarks.benchmarks import *
-    import pyapprox as pya
+import pyapprox as pya
+from pyapprox.benchmarks.benchmarks import *
 
 
 class TestBenchmarks(unittest.TestCase):

--- a/pyapprox/rol_minimize.py
+++ b/pyapprox/rol_minimize.py
@@ -1,9 +1,7 @@
-import numpy as np
-from pyapprox.sys_utilities import package_installed
-if package_installed('ROL'):
+try:
     from pyapprox._rol_minimize import *
     has_ROL = True
-else:
+except (ImportError, ModuleNotFoundError) as e:
     has_ROL = False
 
 import numpy as np
@@ -22,14 +20,14 @@ def pyapprox_minimize(fun, x0, args=(), method='rol-trust-constr', jac=None,
 
     if 'rol' in method and has_ROL:
         if callback is not None:
-            raise Exception(f'Method {method} cannot use callbacks')
+            raise ValueError(f'Method {method} cannot use callbacks')
         if args != ():
-            raise Exception(f'Method {method} cannot use args')
+            raise ValueError(f'Method {method} cannot use args')
         rol_methods = {'rol-trust-constr': None}
         if method in rol_methods:
             rol_method = rol_methods[method]
         else:
-            raise Exception(f"Method {method} not found")
+            raise ValueError(f"Method {method} not found")
         return rol_minimize(
             fun, x0, rol_method, jac, hess, hessp, bounds, constraints, tol,
             options, x_grad)
@@ -63,7 +61,7 @@ def pyapprox_minimize(fun, x0, args=(), method='rol-trust-constr', jac=None,
             fun, x0, args, method, jac, hess, hessp, bounds, constraints, tol,
             callback, options)
 
-    raise Exception(f"Method {method} was not found")
+    raise ValueError(f"Method {method} was not found")
 
 
 if __name__ == '__main__':

--- a/pyapprox/sys_utilities.py
+++ b/pyapprox/sys_utilities.py
@@ -41,10 +41,11 @@ def hash_array(array, decimals=None):
     return hash(array.tobytes())
 
 
-def package_installed(name):
-    installed_pkgs = {pkg.key for pkg in pkg_resources.working_set}
-    return name in installed_pkgs
-
-
-def module_exists(name):
-    return importlib.util.find_spec(name) is not None
+def package_available(name):
+    pkg_available = True
+    try:
+        mod = importlib.import_module(name)
+    except (ModuleNotFoundError, ImportError):
+        pkg_available = False
+    
+    return pkg_available

--- a/pyapprox/tests/test_random_variable_algebra.py
+++ b/pyapprox/tests/test_random_variable_algebra.py
@@ -93,7 +93,7 @@ class TestRandomVariableAlgebra(unittest.TestCase):
         from matplotlib import pyplot as plt
         plt.hist(
             function(np.random.uniform(lb,ub,10001)),density=True,bins=100)
-        plt.plot(zz,z_pdf_vals); plt.show()
+        # plt.plot(zz,z_pdf_vals); plt.show()
 
         x_cdf = stats.uniform(lb, ub-lb).cdf
         z_cdf_vals = get_cdf_from_monomial_expansion(coef, lb, ub, x_cdf, zz)

--- a/pyapprox_dev/pyapprox_dev/bayesian_inference/tests/test_markov_chain_monte_carlo.py
+++ b/pyapprox_dev/pyapprox_dev/bayesian_inference/tests/test_markov_chain_monte_carlo.py
@@ -9,11 +9,7 @@ from pyapprox.univariate_quadrature import gauss_jacobi_pts_wts_1D
 from pyapprox.bayesian_inference.laplace import \
     laplace_posterior_approximation_for_linear_models
 
-if pya.PYA_DEV_AVAILABLE:
-    from pyapprox_dev.bayesian_inference.markov_chain_monte_carlo import *
-else:
-    import pytest
-    pytestmark = pytest.mark.skip("Skipping test on Windows")
+from pyapprox_dev.bayesian_inference.markov_chain_monte_carlo import *
 
 
 class LinearModel(object):

--- a/pyapprox_dev/pyapprox_dev/bayesian_inference/tests/test_markov_chain_monte_carlo.py
+++ b/pyapprox_dev/pyapprox_dev/bayesian_inference/tests/test_markov_chain_monte_carlo.py
@@ -1,13 +1,19 @@
+import numpy as np
 import unittest
-from functools import partial
 from scipy.stats import norm, uniform
 
-from pyapprox_dev.bayesian_inference.markov_chain_monte_carlo import *
+import pyapprox as pya
 from pyapprox.variables import IndependentMultivariateRandomVariable
 from pyapprox.utilities import get_tensor_product_quadrature_rule
 from pyapprox.univariate_quadrature import gauss_jacobi_pts_wts_1D
 from pyapprox.bayesian_inference.laplace import \
     laplace_posterior_approximation_for_linear_models
+
+if pya.PYA_DEV_AVAILABLE:
+    from pyapprox_dev.bayesian_inference.markov_chain_monte_carlo import *
+else:
+    import pytest
+    pytestmark = pytest.mark.skip("Skipping test on Windows")
 
 
 class LinearModel(object):

--- a/pyapprox_dev/pyapprox_dev/fenics_models/tests/test_helmholtz.py
+++ b/pyapprox_dev/pyapprox_dev/fenics_models/tests/test_helmholtz.py
@@ -1,16 +1,17 @@
 import sys
 import unittest, pytest
+import pyapprox as pya
 
 
-if sys.platform == 'win32':
+if pya.PYA_DEV_AVAILABLE:
+    import dolfin as dl
+    from pyapprox_dev.fenics_models.helmholtz import *
+else:
     pytestmark = pytest.mark.skip("Skipping test on Windows")
 
     # Create stub class
     class dl(object):
         UserExpression = object
-else:
-    import dolfin as dl
-    from pyapprox_dev.fenics_models.helmholtz import *
 
 try:
     import mshr

--- a/pyapprox_dev/pyapprox_dev/fenics_models/tests/test_helmholtz.py
+++ b/pyapprox_dev/pyapprox_dev/fenics_models/tests/test_helmholtz.py
@@ -3,7 +3,7 @@ import unittest, pytest
 import pyapprox as pya
 
 
-if pya.PYA_DEV_AVAILABLE:
+if sys.platform != 'win32':
     import dolfin as dl
     from pyapprox_dev.fenics_models.helmholtz import *
 else:
@@ -16,7 +16,7 @@ else:
 try:
     import mshr
     mshr_package_missing = False
-except:
+except (ImportError, ModuleNotFoundError):
     mshr_package_missing = True
 
 mshr_skiptest = unittest.skipIf(

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = --ignore-glob=pyapprox_dev


### PR DESCRIPTION
I find that the implemented module existence checks were unnecessary or unnecessarily complicated.

FYI - In the first commit message, I wrote:
"Original implementation loops over a relatively large dict. Yes, it's O(1), but that O(1) can still be a relatively large operation."

To clarify, here I am referring to the fact that a `dict` (of all available packages) was being created (`O(n)`), and subsequently the `dict` was checked for the name of the target package as a key entry (`O(1)`). This function was being called (with each call being `O(1)`) multiple times throughout the package. While these `O(1)` operations are small, they can add up and contribute to the (perceived) slow imports.

At times (e.g., L46-53 in https://github.com/sandialabs/pyapprox/commit/93394fbad1b5673b16948e00fa27812daed2411a ) it is simpler and more direct to simply attempt to import the target package. The advantage is that it incurs essentially no runtime cost if successful, in contrast to the original approach. The code is more pythonic and, at least to me, cleaner and easier to understand as well.
