### PR TITLE
CI smoke test (do not merge)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
+    branches: [main, "dev/**"]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main, "dev/**"]
   pull_request:
-    branches: [main]
+    branches: [main, "dev/**"]
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
Throwaway PR to make the guard and scan-pr checks run once so they become available in branch protections. Close without merging