### PR TITLE
Return 0 from Gamma CDF for non-positive inputs

### DIFF
--- a/packages/pyapprox/src/pyapprox/probability/univariate/gamma.py
+++ b/packages/pyapprox/src/pyapprox/probability/univariate/gamma.py
@@ -335,15 +335,24 @@ class GammaMarginal(Generic[Array]):
 
         shape = self._get_shape()
         rate = self._get_rate()
+        # gammainc(k, x) is 0 for x <= 0, and the substitution below is only
+        # valid for x > 0. Evaluating it at a non-positive x gives a spurious
+        # value (negative, greater than one, or NaN when shape < 1), so
+        # evaluate the quadrature on the positive part and zero out the rest.
+        # Substituting ones keeps the masked entries finite so they cannot
+        # poison the autograd graph.
+        positive = samples > 0.0
+        safe_samples = self._bkd.where(positive, samples, self._bkd.ones_like(samples))
         # Transform integral_0^x to integral_0^1 with substitution t = x*u
         # integral_0^x t^{k-1} exp(-t) dt = x^k * integral_0^1 u^{k-1} exp(-x*u) du
         # Using rate: for rate*x instead of x
-        rate_x = rate * samples
+        rate_x = rate * safe_samples
         quadx = rate_x[:, None] * self._quadx_01[None, :]
         quadw = rate_x[:, None] * self._quadw_01[None, :]
         integrand_vals = quadx ** (shape - 1.0) * self._bkd.exp(-quadx)
         integral = self._bkd.sum(integrand_vals * quadw, axis=1)
-        return integral / self._bkd.exp(self._bkd.gammaln(shape))
+        result = integral / self._bkd.exp(self._bkd.gammaln(shape))
+        return self._bkd.where(positive, result, self._bkd.zeros_like(result))
 
     def cdf(self, samples: Array) -> Array:
         """

--- a/packages/pyapprox/tests/probability/univariate/test_univariate_gamma.py
+++ b/packages/pyapprox/tests/probability/univariate/test_univariate_gamma.py
@@ -100,6 +100,33 @@ class TestGammaMarginal:
         expected = self._bkd.asarray([self._scipy_dist.cdf([0.5, 1.0, 2.0, 3.0])])
         assert self._bkd.allclose(cdf_vals, expected, rtol=1e-10)
 
+    def test_cdf_nonpositive_is_zero(self) -> None:
+        """Test CDF is 0 outside the support, as scipy gives."""
+        samples = self._bkd.asarray([[-5.0, -1.0, -1e-3, 0.0]])
+        cdf_vals = self._dist.cdf(samples)
+        expected = self._bkd.asarray([self._scipy_dist.cdf([-5.0, -1.0, -1e-3, 0.0])])
+        assert self._bkd.allclose(cdf_vals, expected, atol=1e-12)
+
+    def test_cdf_nonpositive_is_zero_shape_less_than_one(self) -> None:
+        """Test CDF outside the support for shape < 1, where the integrand is
+        singular at the origin."""
+        shape = 0.5
+        dist = GammaMarginal(
+            shape, self._scale, self._bkd, quadrature_rule=self._quad_rule
+        )
+        scipy_dist = stats.gamma(shape, scale=self._scale)
+        samples = self._bkd.asarray([[-2.0, -0.25, 0.0]])
+        cdf_vals = dist.cdf(samples)
+        expected = self._bkd.asarray([scipy_dist.cdf([-2.0, -0.25, 0.0])])
+        assert self._bkd.allclose(cdf_vals, expected, atol=1e-12)
+
+    def test_cdf_monotonic_across_origin(self) -> None:
+        """Test CDF does not decrease over a grid spanning the origin."""
+        grid = [-2.0, -0.5, 0.0, 0.5, 2.0]
+        cdf_vals = self._dist.cdf(self._bkd.asarray([grid]))
+        diffs = self._bkd.to_numpy(cdf_vals)[0]
+        assert (diffs[1:] - diffs[:-1] >= -1e-9).all()
+
     def test_invcdf_matches_scipy(self) -> None:
         """Test invcdf matches scipy ppf."""
         probs = self._bkd.asarray([[0.1, 0.5, 0.9]])


### PR DESCRIPTION
The Gamma distribution is supported on [0, inf), so its CDF should be 0 for every x <= 0. Right now `GammaMarginal.cdf` returns nonsense there, because `_gammainc` uses the substitution t = x*u, which only holds for x > 0.

With scale=1.5, on current `dev/main`:

- shape=2.0: `cdf(-1.0)` is about 0.50 and `cdf(-5.0)` is about 134, so the CDF is not monotonic and leaves [0, 1] entirely.
- shape=1.0: `cdf(-1.0)` is negative.
- shape=0.5: `cdf(x)` is NaN for x <= 0, including at x=0, since `0 ** (shape - 1)` blows up.

`scipy.stats.gamma(...).cdf` returns 0.0 for all of those.

The fix evaluates the quadrature on the positive part only and masks the rest back to 0. Masked entries get ones substituted before the quadrature so nothing goes non-finite, which keeps the torch autograd graph clean (I checked that d/dx cdf at a positive point still equals the pdf). Positive-x results are untouched.

Tests added for x <= 0 at shape 2.0, for the shape < 1 case where the integrand is singular at the origin, and for monotonicity across a grid spanning zero. All three fail before the change on both backends. After it, `packages/pyapprox/tests/probability/` is 1610 passed, 28 skipped, and `ruff check packages/pyapprox/src/pyapprox/` is clean.

I based this on `dev/main` since that is where development seems to happen. Happy to retarget, or to move the guard up into `cdf()` if you would rather keep `_gammainc` a raw kernel.

I work on open-source supply-chain security and spend a fair amount of time reading numerical code in national-lab projects, which is how I ran into this one.